### PR TITLE
Support read-only root filesystem

### DIFF
--- a/cmd/init/disk.go
+++ b/cmd/init/disk.go
@@ -49,7 +49,7 @@ func setupDisks(disks []vm.Disk) error {
 	return nil
 }
 
-func setupRootdisk(vmdata *vm.Data) error {
+func setupRootdisk(vmdata *vm.Data, readonly bool) error {
 	var disk vm.Disk
 	for i, d := range vmdata.Disks {
 		if d.ID == vmdata.Rootdisk {
@@ -78,6 +78,9 @@ func setupRootdisk(vmdata *vm.Data) error {
 		Target: "/rootfs",
 		Fstype: disk.Fstype,
 		Flags:  0,
+	}
+	if readonly {
+		mnt.Flags |= unix.MS_RDONLY
 	}
 	if err := mount(mnt); err != nil {
 		return err

--- a/cmd/init/entrypoint.go
+++ b/cmd/init/entrypoint.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -56,12 +55,6 @@ func runEntrypoint() error {
 
 	if err := chroot("/rootfs"); err != nil {
 		return err
-	}
-
-	if entrypoint.Runqenv {
-		if err := writeEnvfile(cfg.Envfile, entrypoint.Env); err != nil {
-			return err
-		}
 	}
 
 	if !entrypoint.Systemd {
@@ -228,28 +221,4 @@ func setIDs(uid, gid uint32, gids []uint32) error {
 		return fmt.Errorf("setuid failed: %v", os.NewSyscallError("SYS_SETUID", errno))
 	}
 	return nil
-}
-
-func writeEnvfile(path string, env []string) error {
-	var buf bytes.Buffer
-	for _, v := range env {
-		f := strings.SplitN(v, "=", 2)
-		if len(f) < 2 {
-			continue
-		}
-		if f[1] == "" {
-			v = fmt.Sprintf("%s=%q", f[0], "")
-		} else {
-			r := []rune(f[1])
-			first := r[0]
-			last := r[len(r)-1]
-			if (first != '\'' && first != '"') || (last != '\'' && last != '"') {
-				v = fmt.Sprintf("%s=%q", f[0], f[1])
-			}
-		}
-		if _, err := buf.WriteString(v + "\n"); err != nil {
-			return errors.WithStack(err)
-		}
-	}
-	return errors.WithStack(ioutil.WriteFile(path, buf.Bytes(), 0444))
 }

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -106,24 +106,19 @@ func runInit() error {
 	// including /lib/modules.
 	// When using a rootdisk the 9pfs share contains only /lib/modules
 	if vmdata.Rootdisk == "" {
-		if err := mountInitShare("rootfs", "/rootfs"); err != nil {
+		if err := mountInitShare("rootfs", "/rootfs", vmdata.RootFSReadonly); err != nil {
 			return err
 		}
 	} else {
-		if err := setupRootdisk(vmdata); err != nil {
+		if err := setupRootdisk(vmdata, vmdata.RootFSReadonly); err != nil {
 			return err
 		}
-		if err := mountInitShare("share", "/rootfs/lib/modules"); err != nil {
+		if err := mountInitShare("share", "/rootfs/lib/modules", vmdata.RootFSReadonly); err != nil {
 			return err
 		}
 	}
 	if err := util.CreateSymlink("/rootfs/lib/modules", "/lib/modules"); err != nil {
 		return err
-	}
-
-	// Remove empty mountpoint.
-	if err := os.Remove("/rootfs/qemu"); err != nil && !os.IsNotExist(err) {
-		return errors.WithStack(err)
 	}
 
 	if err := mountInitStage1(vmdata.Mounts); err != nil {

--- a/cmd/init/mount.go
+++ b/cmd/init/mount.go
@@ -48,13 +48,16 @@ func mountInitStage0() error {
 	return mount(mounts...)
 }
 
-func mountInitShare(source, target string) error {
+func mountInitShare(source, target string, readonly bool) error {
 	mnt := vm.Mount{
 		Source: source,
 		Target: target,
 		Fstype: "9p",
 		Flags:  unix.MS_NODEV | unix.MS_DIRSYNC,
 		Data:   "trans=virtio,cache=mmap",
+	}
+	if readonly {
+		mnt.Flags |= unix.MS_RDONLY
 	}
 	return mount(mnt)
 }

--- a/cmd/proxy/disk.go
+++ b/cmd/proxy/disk.go
@@ -226,8 +226,10 @@ func prepareRootdisk(vmdata *vm.Data) error {
 			return fmt.Errorf("rsync failed: %v rc=%d %s", err, rc, msg)
 		}
 	}
-	if err := os.MkdirAll("/lib/modules", 0755); err != nil {
-		return err
+	for _, d := range []string{"/dev", "/proc", "/sys", "/lib/modules"} {
+		if err := os.MkdirAll(dest+"/"+d, 0755); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/runq/runc.patch
+++ b/cmd/runq/runc.patch
@@ -96,10 +96,10 @@ index fd1ad5ff..a9fb4658 100644
  		checkpointCommand,
 diff --git a/runq.go b/runq.go
 new file mode 100644
-index 00000000..e35be936
+index 00000000..774bc128
 --- /dev/null
 +++ b/runq.go
-@@ -0,0 +1,561 @@
+@@ -0,0 +1,565 @@
 +package main
 +
 +import (
@@ -194,10 +194,15 @@ index 00000000..e35be936
 +		Mem:         context.GlobalInt("mem"),
 +		NestedVM:    context.GlobalBool("nestedvm"),
 +		NoExec:      context.GlobalBool("noexec"),
++		Runqenv:     context.GlobalBool("runqenv"),
 +		Sysctl:      spec.Linux.Sysctl,
 +	}
 +
 +	spec.Linux.Sysctl = nil
++
++	if spec.Root.Readonly {
++		vmdata.RootFSReadonly = true
++	}
 +
 +	if err := specDevices(spec, &vmdata); err != nil {
 +		return err
@@ -214,7 +219,6 @@ index 00000000..e35be936
 +		Args:            spec.Process.Args,
 +		Cwd:             spec.Process.Cwd,
 +		NoNewPrivileges: spec.Process.NoNewPrivileges,
-+		Runqenv:         context.GlobalBool("runqenv"),
 +		Terminal:        spec.Process.Terminal,
 +	}
 +
@@ -686,10 +690,10 @@ index 00000000..0df934e8
 +go 1.14
 diff --git a/vendor/github.com/gotoz/runq/pkg/vm/vm.go b/vendor/github.com/gotoz/runq/pkg/vm/vm.go
 new file mode 100644
-index 00000000..a1495c46
+index 00000000..fa43fd15
 --- /dev/null
 +++ b/vendor/github.com/gotoz/runq/pkg/vm/vm.go
-@@ -0,0 +1,228 @@
+@@ -0,0 +1,229 @@
 +// Package vm defines data types and functions define and
 +// share data between the runtime runq, proxy and init.
 +package vm
@@ -800,7 +804,6 @@ index 00000000..a1495c46
 +	Env             []string
 +	NoNewPrivileges bool
 +	Rlimits         map[string]syscall.Rlimit
-+	Runqenv         bool
 +	SeccompGob      []byte
 +	Systemd         bool
 +	Terminal        bool
@@ -835,8 +838,10 @@ index 00000000..a1495c46
 +	NestedVM        bool
 +	Networks        []Network
 +	NoExec          bool
++	RootFSReadonly  bool
 +	Rootdisk        string
 +	RootdiskExclude []string
++	Runqenv         bool
 +	Sysctl          map[string]string
 +	Entrypoint      Entrypoint
 +	Vsockd          Vsockd

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -108,7 +108,6 @@ type Entrypoint struct {
 	Env             []string
 	NoNewPrivileges bool
 	Rlimits         map[string]syscall.Rlimit
-	Runqenv         bool
 	SeccompGob      []byte
 	Systemd         bool
 	Terminal        bool
@@ -143,8 +142,10 @@ type Data struct {
 	NestedVM        bool
 	Networks        []Network
 	NoExec          bool
+	RootFSReadonly  bool
 	Rootdisk        string
 	RootdiskExclude []string
+	Runqenv         bool
 	Sysctl          map[string]string
 	Entrypoint      Entrypoint
 	Vsockd          Vsockd

--- a/test/integration/readonly.sh
+++ b/test/integration/readonly.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+. $(cd ${0%/*};pwd;)/../common.sh
+
+set -u
+
+comment="rootfs is not writable"
+docker run \
+    --runtime runq \
+    --name $(rand_name) \
+    --read-only \
+    --rm \
+    $image  \
+    sh -c "touch /test 2>&1 | grep -q 'Read-only file system'"
+
+checkrc $? 0 "$comment"
+
+comment="rootfs is read-only"
+docker run \
+    --runtime runq \
+    --name $(rand_name) \
+    --read-only \
+    --rm \
+    $image  \
+    awk '$2=="/" { exit(!match($4, "(^|,)ro(,|$)")) }' /proc/mounts
+
+checkrc $? 0 "$comment"
+
+name=$(rand_name)
+file=$PWD/file-$$
+
+cleanup() {
+   docker rm -f $name 2>/dev/null
+   rm -f $file
+   myexit
+}
+trap cleanup 0 2 15
+
+dd if=/dev/zero of=$file bs=1M count=100 >/dev/null
+mkfs.ext4 -F $file
+
+docker run \
+    --runtime runq \
+    --name $name \
+    --init \
+    --volume $file:/dev/runq/0001/none/ext4 \
+    -e RUNQ_ROOTDISK=0001 \
+    --read-only \
+    -d \
+    $image sleep 100
+
+sleep 2
+
+$runq_exec $name sh -c "touch /test 2>&1 | grep -q 'Read-only file system'"
+checkrc $? 0  "rootfs on block device is not writable"
+
+$runq_exec $name awk '$2=="/" { exit(!match($4, "(^|,)ro(,|$)")) }' /proc/mounts
+checkrc $? 0  "rootfs on block device is read-only"
+
+myexit


### PR DESCRIPTION
This patch adds the support of the --read-only option of docker run.
All mount points on root filesystem needs to be created in proxy
in advance.

This commit requires #11  to work correctly.

In Kubernetes, a pod is created with an initial `pause` container, and the CRI plugin of containerd creates a `pause` container with a read-only root filesystem.

Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>