### PR TITLE
Support release image on modern docker, upgrade guest distro to 22.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ include make.rules
 SUBDIRS := cmd/proxy cmd/init cmd/runq cmd/runq-exec cmd/nsenter cmd/vsockd
 TARDIR := runq-$(GIT_COMMIT)
 TARFILE := $(TARDIR).tar.gz
-DOCKER_INIT := /usr/bin/docker-init
 
 .PHONY: all $(SUBDIRS) install image test tarfile release release-install clean distclean version
 
@@ -36,8 +35,8 @@ tarfile:
 release: image
 	docker run \
 		--rm \
+		--init \
 		-v $(CURDIR):/runq \
-		-v $(DOCKER_INIT):/usr/bin/docker-init:ro \
 		$(BUILD_IMAGE) make clean install tarfile clean2
 
 release-install: $(TARFILE)

--- a/cmd/proxy/qemu_amd64.go
+++ b/cmd/proxy/qemu_amd64.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/gotoz/runq/internal/cfg"
 	"github.com/gotoz/runq/pkg/vm"
@@ -17,11 +16,6 @@ func qemuArgs(vmdata *vm.Data, socket, share string) ([]string, error) {
 	if vmdata.NestedVM {
 		cpuArgs = ",pmu=off"
 		virtioArgs = ",disable-modern=true"
-	}
-
-	var shareArgs string
-	if strings.HasPrefix(vmdata.QemuVersion, "4") {
-		shareArgs = ",multidevs=remap"
 	}
 
 	args := []string{
@@ -44,7 +38,7 @@ func qemuArgs(vmdata *vm.Data, socket, share string) ([]string, error) {
 		"-kernel", "/kernel",
 		"-initrd", "/initrd",
 		"-msg", "timestamp=on",
-		"-fsdev", "local,id=share,path=" + share + ",security_model=none" + shareArgs,
+		"-fsdev", "local,id=share,path=" + share + ",security_model=none,multidevs=remap",
 		"-chardev", "socket,path=" + socket + ",id=channel1",
 		"-device", "virtserialport,chardev=channel1,name=com.ibm.runq.channel.1",
 		"-smp", strconv.Itoa(vmdata.CPU),

--- a/cmd/runq/runc.patch
+++ b/cmd/runq/runc.patch
@@ -106,7 +106,7 @@ index 00000000..c033e960
 +)
 +
 +const (
-+	runqOciVersion = "1.0"
++	runqOciVersion = "1."
 +	runqStartcmd   = vm.QemuMountPt + "/proxy"
 +)
 +

--- a/initrd/Makefile
+++ b/initrd/Makefile
@@ -2,13 +2,13 @@ include ../make.rules
 
 .PHONY: initrd
 
-initrd: ../cmd/init/init /usr/bin/docker-init
+initrd: ../cmd/init/init /sbin/docker-init
 	QEMU_ROOT=$(QEMU_ROOT) $(CURDIR)/mkinitrd.sh
 
 install: initrd
 	install -m 0644 -D initrd $(QEMU_ROOT)/initrd
 
-/usr/bin/docker-init:
+/sbin/docker-init:
 	@echo "$@ is required for 'docker run --init ...'"
 	@echo "run 'touch $@' to ignore"; false
 

--- a/initrd/mkinitrd.sh
+++ b/initrd/mkinitrd.sh
@@ -17,7 +17,7 @@ popd >/dev/null
 cp $DIR/../cmd/init/init $TMP_DIR/
 cp $DIR/../cmd/vsockd/vsockd $TMP_DIR/sbin/
 cp $DIR/../cmd/nsenter/nsenter $TMP_DIR/sbin/
-cp /usr/bin/docker-init $TMP_DIR/sbin/
+cp /sbin/docker-init $TMP_DIR/sbin/
 
 pushd $TMP_DIR >/dev/null
 find . | cpio -o -H newc | gzip > $DIR/initrd

--- a/make.rules
+++ b/make.rules
@@ -14,4 +14,4 @@ ARCH := $(shell uname -m)
 GIT_SHA1 := $(shell git rev-parse --short HEAD)
 GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no | grep -v 'M runc'),$(GIT_SHA1)+,$(GIT_SHA1))
 
-BUILD_IMAGE := runq-build-2004
+BUILD_IMAGE := runq-build-2204

--- a/qemu/x86_64/Dockerfile
+++ b/qemu/x86_64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV RUNC_ROOT /runq/runc
 ENV RUNQ_ROOT /var/lib/runq
@@ -41,7 +41,9 @@ RUN mkdir -p \
     $QEMU_ROOT/share \
     $QEMU_ROOT/sys
 
-RUN    echo base  /lib/modules/*/kernel/fs/fscache/fscache.ko                                > $QEMU_ROOT/kernel.conf \
+# netfs/netfs.ko
+RUN    echo base  /lib/modules/*/kernel/fs/netfs/netfs.ko                                    > $QEMU_ROOT/kernel.conf \
+    && echo base  /lib/modules/*/kernel/fs/fscache/fscache.ko                               >> $QEMU_ROOT/kernel.conf \
     && echo base  /lib/modules/*/kernel/net/9p/9pnet.ko                                     >> $QEMU_ROOT/kernel.conf \
     && echo base  /lib/modules/*/kernel/fs/9p/9p.ko                                         >> $QEMU_ROOT/kernel.conf \
     && echo base  /lib/modules/*/kernel/net/9p/9pnet.ko                                     >> $QEMU_ROOT/kernel.conf \
@@ -74,7 +76,6 @@ RUN cp -d --preserve=all --parents \
      /usr/lib64/ld-linux-x86-64.so.2 \
      /usr/lib/ipxe/qemu \
      /usr/lib/modules \
-     /usr/lib/x86_64-linux-gnu/ceph \
      /usr/lib/x86_64-linux-gnu/qemu \
      /usr/sbin/e2fsck \
      /usr/sbin/fsck.ext2 \

--- a/qemu/x86_64/Dockerfile
+++ b/qemu/x86_64/Dockerfile
@@ -35,6 +35,7 @@ RUN set -eu; \
 
 RUN mkdir -p \
     $QEMU_ROOT/dev \
+    $QEMU_ROOT/etc \
     $QEMU_ROOT/proc \
     $QEMU_ROOT/rootfs \
     $QEMU_ROOT/share \
@@ -68,7 +69,6 @@ RUN cp -d --preserve=all --parents \
   $QEMU_ROOT/ 2>&1 | grep -v 'omitting directory';:
 
  RUN cp -a --parents \
-     /etc/mtab \
      /usr/bin/qemu-system-x86_64 \
      /usr/bin/rsync \
      /usr/lib64/ld-linux-x86-64.so.2 \
@@ -87,6 +87,7 @@ RUN cp -d --preserve=all --parents \
      $QEMU_ROOT/
 
 RUN cd $QEMU_ROOT \
+    && ln -s ../proc/self/mounts etc/mtab \
     && ln -s usr/bin bin \
     && ln -s usr/lib64 lib64 \
     && ln -s usr/lib lib \


### PR DESCRIPTION
The first commit fixes #24. It is not clear if #18 is still relevant, but it seems like passing `--init` is simpler to guarantee our `docker-init`.

The second commit brings the guest distro to ubuntu 22.04 (Linux 5.15.0-87-generic as of this PR).
